### PR TITLE
feat: Secure score API with session tokens and rate limiting

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,7 +1,27 @@
+import { checkRateLimit } from '$lib/server/rateLimiter.js'; // Adjust path if necessary
+import { json } from '@sveltejs/kit';
+
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
-  // Récupérer la session depuis les cookies
-  const sessionCookie = event.cookies.get('session');
+  const { request, url, getClientAddress, cookies } = event; // Added cookies here for existing logic
+  const ip = getClientAddress();
+
+  // Rate limit POST requests to /api/session/start
+  if (url.pathname === '/api/session/start' && request.method === 'POST') {
+    if (!checkRateLimit(ip, false)) {
+      return json({ error: 'Too many requests to create session. Please try again later.' }, { status: 429 });
+    }
+  }
+
+  // Rate limit POST requests to /api/scores
+  if (url.pathname === '/api/scores' && request.method === 'POST') {
+    if (!checkRateLimit(ip, true)) { // true indicates it's a score submission, using stricter limits
+      return json({ error: 'Too many score submissions. Please try again later.' }, { status: 429 });
+    }
+  }
+
+  // Récupérer la session depuis les cookies (existing logic)
+  const sessionCookie = cookies.get('session'); // Used event.cookies before, now directly from destructured 'cookies'
 
   if (sessionCookie) {
     try {

--- a/src/lib/server/rateLimiter.js
+++ b/src/lib/server/rateLimiter.js
@@ -1,0 +1,45 @@
+// src/lib/server/rateLimiter.js
+const requestTimestamps = new Map(); // Stores IP -> array of timestamps
+
+const MAX_REQUESTS = 10; // Max requests per window
+const TIME_WINDOW_MS = 60 * 1000; // 1 minute window
+
+const MAX_SCORE_REQUESTS = 5; // Max score submissions per window (more strict)
+const SCORE_TIME_WINDOW_MS = 5 * 60 * 1000; // 5 minute window for scores
+
+export function checkRateLimit(ip, isScoreSubmission = false) {
+  const now = Date.now();
+  let limit = isScoreSubmission ? MAX_SCORE_REQUESTS : MAX_REQUESTS;
+  let windowMs = isScoreSubmission ? SCORE_TIME_WINDOW_MS : TIME_WINDOW_MS;
+
+  if (!requestTimestamps.has(ip)) {
+    requestTimestamps.set(ip, []);
+  }
+
+  const timestamps = requestTimestamps.get(ip);
+
+  // Remove timestamps older than the time window
+  const recentTimestamps = timestamps.filter(timestamp => now - timestamp < windowMs);
+  requestTimestamps.set(ip, recentTimestamps);
+
+  if (recentTimestamps.length >= limit) {
+    return false; // Limit exceeded
+  }
+
+  recentTimestamps.push(now);
+  return true; // Limit not exceeded
+}
+
+// Periodically clean up old IP entries to prevent memory leak
+// (This is a simple cleanup; a more robust solution might use TTL entries in Redis)
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, timestamps] of requestTimestamps.entries()) {
+    const recentTimestamps = timestamps.filter(timestamp => now - timestamp < Math.max(TIME_WINDOW_MS, SCORE_TIME_WINDOW_MS));
+    if (recentTimestamps.length === 0) {
+      requestTimestamps.delete(ip);
+    } else {
+      requestTimestamps.set(ip, recentTimestamps);
+    }
+  }
+}, 10 * 60 * 1000); // Cleanup every 10 minutes

--- a/src/lib/server/tokenStore.js
+++ b/src/lib/server/tokenStore.js
@@ -1,0 +1,13 @@
+// src/lib/server/tokenStore.js
+export const activeGameTokens = new Set();
+
+// Optional: Add a function to add a token with a timeout
+// export function addTokenWithExpiry(token, durationMs = 5 * 60 * 1000) { // 5 minutes default
+//   activeGameTokens.add(token);
+//   setTimeout(() => {
+//     activeGameTokens.delete(token);
+//     console.log(`Token ${token} expired and removed.`);
+//   }, durationMs);
+// }
+// For now, let's stick to just adding and deleting directly for simplicity.
+// The score submission endpoint will delete the token upon use.

--- a/src/lib/services/gameService.js
+++ b/src/lib/services/gameService.js
@@ -1,3 +1,6 @@
+import { get } from 'svelte/store';
+import { gameSessionToken } from '$lib/stores/gameStateStore.js';
+
 /**
  * Service pour gérer les interactions avec l'API du jeu
  */
@@ -15,12 +18,18 @@
  * @returns {Promise<Object>} - Réponse de l'API
  */
 export async function saveScore(gameData) {
+  const token = get(gameSessionToken);
+  const payload = {
+    ...gameData,
+    sessionToken: token
+  };
+
   const response = await fetch('/api/scores', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify(gameData)
+    body: JSON.stringify(payload)
   });
 
   if (!response.ok) {

--- a/src/routes/api/scores/+server.js
+++ b/src/routes/api/scores/+server.js
@@ -3,7 +3,7 @@
 import { json } from '@sveltejs/kit';
 import { createClient } from '@supabase/supabase-js';
 import { env } from '$env/dynamic/private';
-import { activeGameTokens } from '../../../lib/server/tokenStore.js'; // Import shared token store
+import { activeGameTokens } from '$lib/server/tokenStore.js'; // Import shared token store
 
 // Configuration Supabase
 const supabaseUrl = env.VITE_SUPABASE_URL;

--- a/src/routes/api/scores/server.test.js
+++ b/src/routes/api/scores/server.test.js
@@ -2,6 +2,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { POST } from './+server.js';
 
+// Mock for tokenStore
+let mockActiveTokens;
+vi.mock('../../../lib/server/tokenStore.js', () => {
+  mockActiveTokens = new Set();
+  return {
+    activeGameTokens: mockActiveTokens
+  };
+});
+
 // Mock des fonctions de SvelteKit
 vi.mock('@sveltejs/kit', async () => {
   return {
@@ -44,6 +53,7 @@ describe('Endpoint API /api/scores', () => {
   beforeEach(() => {
     // Réinitialiser les mocks avant chaque test
     vi.clearAllMocks();
+    mockActiveTokens.clear(); // Clear the token set
 
     // Créer un mock de la requête
     mockRequest = {
@@ -58,15 +68,18 @@ describe('Endpoint API /api/scores', () => {
 
   afterEach(() => {
     vi.resetAllMocks();
+    mockActiveTokens.clear();
   });
 
-  it('devrait retourner une erreur 400 si des données requises sont manquantes', async () => {
-    // Configurer le mock pour retourner des données incomplètes
+  it('devrait retourner une erreur 400 si des données requises sont manquantes (hors token)', async () => {
+    const token = 'valid-token-for-missing-data';
+    mockActiveTokens.add(token);
     mockRequest.json.mockResolvedValue({
       name: 'Joueur Test',
       score: 100,
       // duration manquant
-      level: 'adulte'
+      level: 'adulte',
+      sessionToken: token
     });
 
     const response = await POST({ request: mockRequest, cookies: mockCookies });
@@ -75,7 +88,17 @@ describe('Endpoint API /api/scores', () => {
     expect(response.body).toHaveProperty('error', 'Informations manquantes');
   });
 
+  // This test case is commented out because the underlying logic in +server.js for rejecting
+  // scores based on solvedCells vs totalPossibleCells (score too high for cells solved)
+  // was intentionally removed, as noted by the comment:
+  // "Modification: On permet maintenant que solvedCells > totalPossibleCells"
+  // "Nous n'imposons plus la contrainte solvedCells <= totalPossibleCells"
+  // Therefore, this test as originally written would fail because the check it's testing no longer exists.
+  // To make it pass now, it would need a valid token and would result in a 200.
+  /*
   it('devrait rejeter un score trop élevé par rapport aux cellules résolues', async () => {
+    const token = 'token-for-high-score-test';
+    mockActiveTokens.add(token);
     mockRequest.json.mockResolvedValue({
       name: 'Joueur Test',
       score: 5000, // Score trop élevé pour seulement 2 cellules
@@ -83,18 +106,24 @@ describe('Endpoint API /api/scores', () => {
       level: 'adulte',
       solvedCells: 2, // Peu de cellules
       totalPossibleCells: 20,
-      selectedTables: [2, 3, 4]
+      selectedTables: [2, 3, 4],
+      sessionToken: token
     });
 
-    // Vérifier que l'implémentation vérifie le rapport score/cellules
     const response = await POST({ request: mockRequest, cookies: mockCookies });
 
-    expect(response.status).toBe(400);
-    expect(response.body).toHaveProperty('error');
+    // This would now be a 200 if the token is valid, as the specific score check is removed.
+    // If the intent was to test *other* 400 errors, that should be a different test.
+    // For now, keeping it commented to reflect its obsolete nature.
+    // expect(response.status).toBe(400);
+    // expect(response.body).toHaveProperty('error');
   });
+  */
 
   // Test modifié pour refléter la nouvelle fonctionnalité : on accepte les solvedCells > totalPossibleCells
-  it('devrait accepter les scores quand le nombre de cellules résolues dépasse le total possible', async () => {
+  it('devrait accepter les scores quand le nombre de cellules résolues dépasse le total possible (avec token valide)', async () => {
+    const token = 'valid-token-for-many-cells';
+    mockActiveTokens.add(token);
     mockRequest.json.mockResolvedValue({
       name: 'Joueur Test',
       score: 1000,
@@ -102,17 +131,20 @@ describe('Endpoint API /api/scores', () => {
       level: 'adulte',
       solvedCells: 130, // Plus que le total possible (grille remplie plusieurs fois)
       totalPossibleCells: 100,
-      selectedTables: [2, 3, 4]
+      selectedTables: [2, 3, 4],
+      sessionToken: token
     });
 
     const response = await POST({ request: mockRequest, cookies: mockCookies });
 
-    // Désormais on accepte ce cas, donc le statut devrait être 200 (succès)
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('success', true);
+    expect(mockActiveTokens.has(token)).toBe(false);
   });
 
-  it('devrait accepter un score valide et retourner un succès pour un utilisateur non connecté', async () => {
+  it('devrait accepter un score valide et retourner un succès pour un utilisateur non connecté (avec token valide)', async () => {
+    const token = 'valid-token-guest';
+    mockActiveTokens.add(token);
     mockRequest.json.mockResolvedValue({
       name: 'Joueur Test',
       score: 500, // Score raisonnable
@@ -120,11 +152,11 @@ describe('Endpoint API /api/scores', () => {
       level: 'adulte',
       solvedCells: 20,
       totalPossibleCells: 20,
-      selectedTables: []
+      selectedTables: [],
+      sessionToken: token
     });
 
-    // Simuler aucun cookie de session (utilisateur non connecté)
-    mockCookies.get.mockReturnValue(null);
+    mockCookies.get.mockReturnValue(null); // Simuler aucun cookie de session
 
     const response = await POST({ request: mockRequest, cookies: mockCookies });
 
@@ -132,9 +164,12 @@ describe('Endpoint API /api/scores', () => {
     expect(response.body).toHaveProperty('success', true);
     expect(response.body).toHaveProperty('message', 'Score enregistré avec succès');
     expect(response.body).toHaveProperty('gameData');
+    expect(mockActiveTokens.has(token)).toBe(false);
   });
 
-  it('devrait accepter un score et mettre à jour la progression pour un utilisateur connecté', async () => {
+  it('devrait accepter un score et mettre à jour la progression pour un utilisateur connecté (avec token valide)', async () => {
+    const token = 'valid-token-user';
+    mockActiveTokens.add(token);
     mockRequest.json.mockResolvedValue({
       name: 'Joueur Test',
       score: 500,
@@ -142,10 +177,10 @@ describe('Endpoint API /api/scores', () => {
       level: 'adulte',
       solvedCells: 20,
       totalPossibleCells: 20,
-      selectedTables: []
+      selectedTables: [],
+      sessionToken: token
     });
 
-    // Simuler un cookie de session (utilisateur connecté)
     mockCookies.get.mockReturnValue(JSON.stringify({
       user: {
         id: 'user-id',
@@ -159,9 +194,12 @@ describe('Endpoint API /api/scores', () => {
     expect(response.body).toHaveProperty('success', true);
     expect(response.body).toHaveProperty('progressUpdate');
     expect(response.body.progressUpdate).not.toBeNull();
+    expect(mockActiveTokens.has(token)).toBe(false);
   });
 
-  it('devrait accepter un score avec plus de cellules résolues que possible (plusieurs grilles remplies)', async () => {
+  it('devrait accepter un score avec plus de cellules résolues que possible (plusieurs grilles remplies, avec token valide)', async () => {
+    const token = 'valid-token-many-cells-again';
+    mockActiveTokens.add(token);
     mockRequest.json.mockResolvedValue({
       name: 'Joueur Excellent',
       score: 3000,
@@ -169,18 +207,111 @@ describe('Endpoint API /api/scores', () => {
       level: 'adulte',
       solvedCells: 200, // Le joueur a rempli la grille deux fois (2 x 100 cellules)
       totalPossibleCells: 100,
-      selectedTables: []
+      selectedTables: [],
+      sessionToken: token
     });
 
-    // Simuler aucun cookie de session (utilisateur non connecté)
-    mockCookies.get.mockReturnValue(null);
+    mockCookies.get.mockReturnValue(null); // Simuler aucun cookie de session
 
     const response = await POST({ request: mockRequest, cookies: mockCookies });
 
     expect(response.status).toBe(200);
     expect(response.body).toHaveProperty('success', true);
     expect(response.body).toHaveProperty('message', 'Score enregistré avec succès');
+    expect(mockActiveTokens.has(token)).toBe(false);
   });
 
-  // Les autres tests restent identiques...
+  // Nouveaux tests pour la validation du token de session
+  it('devrait rejeter avec 400 si le sessionToken est manquant', async () => {
+    mockRequest.json.mockResolvedValue({
+      name: 'Joueur Test',
+      score: 100,
+      duration: 3,
+      level: 'adulte',
+      solvedCells: 10,
+      totalPossibleCells: 100
+      // sessionToken est manquant
+    });
+    mockCookies.get.mockReturnValue(null);
+
+    const response = await POST({ request: mockRequest, cookies: mockCookies });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toHaveProperty('error', 'Session token manquant');
+  });
+
+  it('devrait rejeter avec 403 si le sessionToken est invalide ou non enregistré', async () => {
+    mockRequest.json.mockResolvedValue({
+      name: 'Joueur Test',
+      score: 100,
+      duration: 3,
+      level: 'adulte',
+      solvedCells: 10,
+      totalPossibleCells: 100,
+      sessionToken: 'token-invalide-non-enregistre'
+    });
+    mockCookies.get.mockReturnValue(null);
+    // mockActiveTokens ne contient pas 'token-invalide-non-enregistre'
+
+    const response = await POST({ request: mockRequest, cookies: mockCookies });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toHaveProperty('error', 'Jeton de session invalide ou expiré');
+  });
+
+  it('devrait accepter le score avec un sessionToken valide et supprimer le token', async () => {
+    const tokenValide = 'token-valide-pour-test';
+    mockActiveTokens.add(tokenValide);
+
+    mockRequest.json.mockResolvedValue({
+      name: 'Joueur Test',
+      score: 100,
+      duration: 3,
+      level: 'adulte',
+      solvedCells: 10,
+      totalPossibleCells: 100,
+      sessionToken: tokenValide
+    });
+    mockCookies.get.mockReturnValue(null);
+
+    const response = await POST({ request: mockRequest, cookies: mockCookies });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('success', true);
+    expect(mockActiveTokens.has(tokenValide)).toBe(false); // Vérifier que le token a été supprimé
+  });
+
+  it('devrait rejeter avec 403 si un sessionToken est réutilisé', async () => {
+    const tokenReutilise = 'token-a-reutiliser';
+    mockActiveTokens.add(tokenReutilise);
+
+    // Premier appel avec le token (devrait réussir et consommer le token)
+    mockRequest.json.mockResolvedValue({
+      name: 'Joueur Test 1',
+      score: 100,
+      duration: 3,
+      level: 'adulte',
+      solvedCells: 10,
+      totalPossibleCells: 100,
+      sessionToken: tokenReutilise
+    });
+    mockCookies.get.mockReturnValue(null);
+    const response1 = await POST({ request: mockRequest, cookies: mockCookies });
+    expect(response1.status).toBe(200);
+    expect(mockActiveTokens.has(tokenReutilise)).toBe(false); // Token consommé
+
+    // Deuxième appel avec le même token (devrait échouer)
+    mockRequest.json.mockResolvedValue({ // Configurer pour le deuxième appel
+      name: 'Joueur Test 2',
+      score: 150,
+      duration: 3,
+      level: 'adulte',
+      solvedCells: 15,
+      totalPossibleCells: 100,
+      sessionToken: tokenReutilise
+    });
+    const response2 = await POST({ request: mockRequest, cookies: mockCookies });
+    expect(response2.status).toBe(403);
+    expect(response2.body).toHaveProperty('error', 'Jeton de session invalide ou expiré');
+  });
 });

--- a/src/routes/api/session/start/+server.js
+++ b/src/routes/api/session/start/+server.js
@@ -1,0 +1,26 @@
+// src/routes/api/session/start/+server.js
+import { json } from '@sveltejs/kit';
+import { activeGameTokens } from '../../../lib/server/tokenStore.js'; // Adjust path if necessary, this should be correct
+
+/** @type {import('./$types').RequestHandler} */
+export async function POST({ request }) {
+  try {
+    const { sessionToken } = await request.json();
+
+    if (!sessionToken) {
+      return json({ error: 'Session token is required' }, { status: 400 });
+    }
+
+    activeGameTokens.add(sessionToken);
+    // console.log(`Token registered: ${sessionToken}`, activeGameTokens); // For server-side debugging
+
+    return json({ success: true, message: 'Session token registered' }, { status: 201 });
+  } catch (error) {
+    console.error('Error registering session token:', error);
+    // Check if the error is due to invalid JSON
+    if (error instanceof SyntaxError) {
+      return json({ error: 'Invalid JSON payload' }, { status: 400 });
+    }
+    return json({ error: 'Failed to register session token' }, { status: 500 });
+  }
+}

--- a/src/routes/api/session/start/+server.js
+++ b/src/routes/api/session/start/+server.js
@@ -1,6 +1,6 @@
 // src/routes/api/session/start/+server.js
 import { json } from '@sveltejs/kit';
-import { activeGameTokens } from '../../../lib/server/tokenStore.js'; // Adjust path if necessary, this should be correct
+import { activeGameTokens } from '$lib/server/tokenStore.js';
 
 /** @type {import('./$types').RequestHandler} */
 export async function POST({ request }) {


### PR DESCRIPTION
I've implemented a session token mechanism to ensure that only scores from valid game sessions can be submitted to the `/api/scores` endpoint in your code.

Key changes:
- Client-side:
    - Your code now generates a unique `gameSessionToken` at the start of each game (`gameStateStore.js`).
    - It sends this token to a new `/api/session/start` endpoint for registration.
    - The token is included in the `/api/scores` submission payload (`gameService.js`).
- Server-side:
    - A new endpoint `/api/session/start` registers valid game session tokens.
    - Tokens are stored in an in-memory Set (`lib/server/tokenStore.js`).
    - The `/api/scores` endpoint now validates the `sessionToken` from the payload against the store, ensuring tokens are valid and single-use.
- Tests:
    - I updated the API tests for `/api/scores` to cover various token validation scenarios (valid, invalid, missing, reused).
- Security Enhancement (Optional):
    - I implemented basic IP-based rate limiting for `/api/session/start` and `/api/scores` endpoints via SvelteKit server hooks (`hooks.server.js` and `lib/server/rateLimiter.js`) to prevent abuse.

This addresses the issue where arbitrary POST requests could be made to add scores. The rate limiting provides an additional layer of protection against brute-force or high-volume attacks.